### PR TITLE
Add `gitattributes` file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary


### PR DESCRIPTION
According to https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings this should help fix our `.png` corruption issues without having to get all into the git config for non-dev users.